### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,7 +76,7 @@ jobs:
         build_directory: out
 
     - name: Publish to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       if: ${{ env.DOCKER_USERNAME != '' && env.DOCKER_USERNAME != '' && env.steps.semantic.outputs.new_release_published == true }} 
       with:
         name: ${{ env.GIT_REPO }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore